### PR TITLE
remove a bunch of 'any' types

### DIFF
--- a/packages/observable/src/observable.spec.ts
+++ b/packages/observable/src/observable.spec.ts
@@ -358,10 +358,10 @@ describe('Observable', () => {
         for await (const value of source) {
           results.push(value);
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
         thrownError = err;
       }
-
+      expect(thrownError instanceof Error).to.be.true;
       expect(thrownError?.message).to.equal('wee');
       expect(results).to.deep.equal([1, 2]);
     });

--- a/packages/observable/src/observable.ts
+++ b/packages/observable/src/observable.ts
@@ -1110,6 +1110,8 @@ export function from<T>(input: ObservableInput<T>): Observable<T> {
     case ObservableInputType.Own:
       return input as Observable<T>;
     case ObservableInputType.InteropObservable:
+      if (!isInteropObservable<T>(input))
+        throw new Error('unreachable error for type-narrowing');
       return fromInteropObservable(input);
     case ObservableInputType.ArrayLike:
       return fromArrayLike(input as ArrayLike<T>);
@@ -1128,14 +1130,10 @@ export function from<T>(input: ObservableInput<T>): Observable<T> {
  * Creates an RxJS Observable from an object that implements `Symbol.observable`.
  * @param obj An object that properly implements `Symbol.observable`.
  */
-function fromInteropObservable<T>(obj: any) {
+function fromInteropObservable<T>(obj: InteropObservable<T>) {
   return new Observable((subscriber: Subscriber<T>) => {
-    const obs = obj[Symbol.observable ?? '@@observable']();
-    if (isFunction(obs.subscribe)) {
-      return obs.subscribe(subscriber);
-    }
-    // Should be caught by observable subscribe function error handling.
-    throw new TypeError('Provided object does not correctly implement Symbol.observable');
+    const obs = Reflect.get(obj, Symbol.observable ?? '@@observable')();
+    return obs.subscribe(subscriber);
   });
 }
 

--- a/packages/observable/src/observable.ts
+++ b/packages/observable/src/observable.ts
@@ -487,7 +487,7 @@ class ConsumerObserver<T> implements Observer<T> {
 }
 
 function createSafeObserver<T>(observerOrNext?: Partial<Observer<T>> | ((value: T) => void) | null): Observer<T> {
-  return new ConsumerObserver(!observerOrNext || isFunction(observerOrNext) ? { next: observerOrNext ?? undefined } : observerOrNext);
+  return new ConsumerObserver(!observerOrNext || typeof observerOrNext === 'function' ? { next: observerOrNext ?? undefined } : observerOrNext);
 }
 
 /**
@@ -1239,6 +1239,11 @@ export enum ObservableInputType {
 }
 
 export function getObservableInputType(input: unknown): ObservableInputType {
+  if (typeof input !== 'object' || input === null) {
+    throw new TypeError(
+    `You provided '${input}' where a stream was expected. You can provide an Observable, Promise, ReadableStream, Array, AsyncIterable, or Iterable.`
+    );
+  }
   if (input instanceof Observable) {
     return ObservableInputType.Own;
   }
@@ -1261,9 +1266,7 @@ export function getObservableInputType(input: unknown): ObservableInputType {
     return ObservableInputType.ReadableStreamLike;
   }
   throw new TypeError(
-    `You provided ${
-      input !== null && typeof input === 'object' ? 'an invalid object' : `'${input}'`
-    } where a stream was expected. You can provide an Observable, Promise, ReadableStream, Array, AsyncIterable, or Iterable.`
+    `You provided an invalid object where a stream was expected. You can provide an Observable, Promise, ReadableStream, Array, AsyncIterable, or Iterable.`
   );
 }
 
@@ -1271,12 +1274,16 @@ export function getObservableInputType(input: unknown): ObservableInputType {
  * Returns true if the object is a function.
  * @param value The value to check
  */
-export function isFunction(value: any): value is (...args: any[]) => any {
+export function isFunction(value: unknown): value is (...args: unknown[]) => unknown {
   return typeof value === 'function';
 }
 
-function isAsyncIterable<T>(obj: any): obj is AsyncIterable<T> {
-  return Symbol.asyncIterator && isFunction(obj?.[Symbol.asyncIterator]);
+function hasMethod(value: object, method: string | symbol): boolean {
+  return isFunction(Reflect.get(value, method));
+}
+
+function isAsyncIterable<T>(obj: object): obj is AsyncIterable<T> {
+  return Symbol.asyncIterator && hasMethod(obj, Symbol.asyncIterator);
 }
 
 export async function* readableStreamLikeToAsyncGenerator<T>(readableStream: ReadableStreamLike<T>): AsyncGenerator<T> {
@@ -1294,42 +1301,42 @@ export async function* readableStreamLikeToAsyncGenerator<T>(readableStream: Rea
   }
 }
 
-function isReadableStreamLike<T>(obj: any): obj is ReadableStreamLike<T> {
+function isReadableStreamLike<T>(obj: object): obj is ReadableStreamLike<T> {
   // We don't want to use instanceof checks because they would return
   // false for instances from another Realm, like an <iframe>.
-  return isFunction(obj?.getReader);
+  return hasMethod(obj, 'getReader');
 }
 
 /**
  * Tests to see if the object is "thennable".
  * @param value the object to test
  */
-export function isPromise(value: any): value is PromiseLike<any> {
-  return isFunction(value?.then);
+export function isPromise(value: unknown): value is PromiseLike<unknown> {
+  return typeof value === 'object' && !!value && hasMethod(value, 'then');
 }
 
 /** Identifies an input as being Observable (but not necessary an Rx Observable) */
-function isInteropObservable(input: any): input is InteropObservable<any> {
-  return isFunction(input[Symbol.observable ?? '@@observable']);
+function isInteropObservable<T = unknown>(input: object): input is InteropObservable<T> {
+  return hasMethod(input, Symbol.observable ?? '@@observable');
 }
 
 /** Identifies an input as being an Iterable */
-function isIterable(input: any): input is Iterable<any> {
-  return isFunction(input?.[Symbol.iterator]);
+function isIterable(input: object): input is Iterable<unknown> {
+  return hasMethod(input, Symbol.iterator);
 }
 
-export function isArrayLike<T>(x: any): x is ArrayLike<T> {
-  return x && typeof x.length === 'number' && !isFunction(x);
+export function isArrayLike<T>(x: unknown): x is ArrayLike<T> {
+  return typeof x === 'object' && !!x && 'length' in x && typeof x.length === 'number';
 }
 
 /**
  * Tests to see if the object is an RxJS {@link Observable}
  * @param obj the object to test
  */
-export function isObservable(obj: any): obj is Observable<unknown> {
+export function isObservable(obj: unknown): obj is Observable<unknown> {
   // The !! is to ensure that this publicly exposed function returns
   // `false` if something like `null` or `0` is passed.
-  return !!obj && (obj instanceof Observable || (isFunction(obj.lift) && isFunction(obj.subscribe)));
+  return !!obj && (obj instanceof Observable || (hasMethod(obj, 'lift') && hasMethod(obj, 'subscribe')));
 }
 
 /**

--- a/packages/observable/src/observable.ts
+++ b/packages/observable/src/observable.ts
@@ -25,7 +25,7 @@ export class UnsubscriptionError extends Error {
    * @deprecated Internal implementation detail. Do not construct error instances.
    * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
    */
-  constructor(public errors: any[]) {
+  constructor(public errors: unknown[]) {
     super(
       errors
         ? `${errors.length} errors occurred during unsubscription:
@@ -76,7 +76,7 @@ export class Subscription implements SubscriptionLike {
    * started when the Subscription was created.
    */
   unsubscribe(): void {
-    let errors: any[] | undefined;
+    let errors: unknown[] | undefined;
 
     if (!this.closed) {
       this.closed = true;
@@ -213,7 +213,7 @@ export interface SubscriberOverrides<T> {
    * the destination's `error` method.
    * @param err An error that has been thrown by the source observable.
    */
-  error?: (err: any) => void;
+  error?: (err: unknown) => void;
   /**
    * If provided, this function will be called whenever the {@link Subscriber}'s
    * `complete` method is called. If an error is thrown within this function, it
@@ -245,7 +245,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   /** @internal */
   protected readonly _nextOverride: ((value: T) => void) | null = null;
   /** @internal */
-  protected readonly _errorOverride: ((err: any) => void) | null = null;
+  protected readonly _errorOverride: ((err: unknown) => void) | null = null;
   /** @internal */
   protected readonly _completeOverride: (() => void) | null = null;
   /** @internal */
@@ -259,7 +259,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   /**
    * @internal
    */
-  constructor(destination: Subscriber<any> | Partial<Observer<any>> | ((value: any) => void) | null, overrides: SubscriberOverrides<T>);
+  constructor(destination: Subscriber<any> | Partial<Observer<unknown>> | ((value: unknown) => void) | null, overrides: SubscriberOverrides<T>);
 
   /**
    * Creates an instance of an RxJS Subscriber. This is the workhorse of the library.
@@ -328,7 +328,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
    * the Observable has experienced an error condition.
    * @param err The `error` exception.
    */
-  error(err?: any): void {
+  error(err?: unknown): void {
     if (this.isStopped) {
       handleStoppedNotification(errorNotification(err), this);
     } else {
@@ -363,7 +363,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     this.destination.next(value);
   }
 
-  protected _error(err: any): void {
+  protected _error(err: unknown): void {
     try {
       this.destination.error(err);
     } finally {
@@ -404,7 +404,7 @@ export interface GlobalConfig {
    * we do not want errors thrown in this user-configured handler to interfere with the
    * behavior of the library.
    */
-  onUnhandledError: ((err: any) => void) | null;
+  onUnhandledError: ((err: unknown) => void) | null;
 
   /**
    * A registration point for notifications that cannot be sent to subscribers because they
@@ -416,7 +416,7 @@ export interface GlobalConfig {
    * we do not want errors thrown in this user-configured handler to interfere with the
    * behavior of the library.
    */
-  onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
+  onStoppedNotification: ((notification: ObservableNotification<unknown>, subscriber: Subscriber<unknown>) => void) | null;
 }
 
 function overrideNext<T>(this: Subscriber<T>, value: T): void {
@@ -427,7 +427,7 @@ function overrideNext<T>(this: Subscriber<T>, value: T): void {
   }
 }
 
-function overrideError(this: Subscriber<unknown>, err: any): void {
+function overrideError(this: Subscriber<unknown>, err: unknown): void {
   try {
     this._errorOverride!(err);
   } catch (error) {
@@ -461,7 +461,7 @@ class ConsumerObserver<T> implements Observer<T> {
     }
   }
 
-  error(err: any): void {
+  error(err: unknown): void {
     const { partialObserver } = this;
     if (partialObserver.error) {
       try {
@@ -495,7 +495,7 @@ function createSafeObserver<T>(observerOrNext?: Partial<Observer<T>> | ((value: 
  * @param notification The notification being sent.
  * @param subscriber The stopped subscriber.
  */
-function handleStoppedNotification(notification: ObservableNotification<any>, subscriber: Subscriber<any>) {
+function handleStoppedNotification(notification: ObservableNotification<unknown>, subscriber: Subscriber<any>) {
   const { onStoppedNotification } = config;
   onStoppedNotification && setTimeout(() => onStoppedNotification(notification, subscriber));
 }
@@ -773,7 +773,7 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   /** @internal */
-  protected _subscribe(_subscriber: Subscriber<any>): TeardownLogic {
+  protected _subscribe(_subscriber: Subscriber<T>): TeardownLogic {
     return;
   }
 
@@ -845,7 +845,7 @@ export class Observable<T> implements Subscribable<T> {
     op7: UnaryFunction<F, G>,
     op8: UnaryFunction<G, H>,
     op9: UnaryFunction<H, I>,
-    ...operations: OperatorFunction<any, any>[]
+    ...operations: OperatorFunction<unknown, unknown>[]
   ): Observable<unknown>;
   pipe<A, B, C, D, E, F, G, H, I>(
     op1: UnaryFunction<Observable<T>, A>,
@@ -857,7 +857,7 @@ export class Observable<T> implements Subscribable<T> {
     op7: UnaryFunction<F, G>,
     op8: UnaryFunction<G, H>,
     op9: UnaryFunction<H, I>,
-    ...operations: UnaryFunction<any, any>[]
+    ...operations: UnaryFunction<unknown, unknown>[]
   ): unknown;
 
   /**
@@ -880,8 +880,8 @@ export class Observable<T> implements Subscribable<T> {
    * @return The Observable result of all the operators having been called
    * in the order they were passed in.
    */
-  pipe(...operations: UnaryFunction<any, any>[]): unknown {
-    return operations.reduce(pipeReducer, this as any);
+  pipe(...operations: UnaryFunction<any, unknown>[]): unknown {
+    return operations.reduce(pipeReducer, this);
   }
 
   /**
@@ -1007,7 +1007,7 @@ export class Observable<T> implements Subscribable<T> {
   }
 }
 
-function pipeReducer(prev: any, fn: UnaryFunction<any, any>) {
+function pipeReducer(prev: unknown, fn: UnaryFunction<unknown, unknown>) {
   return fn(prev);
 }
 
@@ -1020,7 +1020,7 @@ function pipeReducer(prev: any, fn: UnaryFunction<any, any>) {
  *
  * @param err the error to report
  */
-export function reportUnhandledError(err: any) {
+export function reportUnhandledError(err: unknown) {
   setTimeout(() => {
     const { onUnhandledError } = config;
     if (onUnhandledError) {
@@ -1103,7 +1103,7 @@ export function reportUnhandledError(err: any) {
  * an Array, an iterable, async iterable, or an array-like object to be converted.
  */
 
-export function from<O extends ObservableInput<any>>(input: O): Observable<ObservedValueOf<O>>;
+export function from<O extends ObservableInput<unknown>>(input: O): Observable<ObservedValueOf<O>>;
 export function from<T>(input: ObservableInput<T>): Observable<T> {
   const type = getObservableInputType(input);
   switch (type) {
@@ -1160,7 +1160,7 @@ export function fromPromise<T>(promise: PromiseLike<T>) {
             subscriber.complete();
           }
         },
-        (err: any) => subscriber.error(err)
+        (err: unknown) => subscriber.error(err)
       )
       .then(null, reportUnhandledError);
   });
@@ -1349,8 +1349,8 @@ export const COMPLETE_NOTIFICATION = (() => createNotification('C', undefined, u
  * as other notifications.
  * @internal
  */
-export function errorNotification(error: any): ErrorNotification {
-  return createNotification('E', undefined, error) as any;
+export function errorNotification(error: unknown): ErrorNotification {
+  return createNotification('E', undefined, error);
 }
 
 /**
@@ -1363,13 +1363,13 @@ export function nextNotification<T>(value: T) {
 }
 
 export function createNotification<T>(kind: 'N', value: T, error: undefined): { kind: 'N'; value: T; error: undefined };
-export function createNotification<T>(kind: 'E', value: undefined, error: any): { kind: 'E'; value: undefined; error: any };
+export function createNotification<T>(kind: 'E', value: undefined, error: unknown): { kind: 'E'; value: undefined; error: unknown };
 export function createNotification<T>(kind: 'C', value: undefined, error: undefined): { kind: 'C'; value: undefined; error: undefined };
 export function createNotification<T>(
   kind: 'N' | 'E' | 'C',
   value: T | undefined,
-  error: any
-): { kind: 'N' | 'E' | 'C'; value: T | undefined; error: any };
+  error: unknown
+): { kind: 'N' | 'E' | 'C'; value: T | undefined; error: unknown };
 
 /**
  * Ensures that all notifications created internally have the same "shape" in v8.
@@ -1377,7 +1377,7 @@ export function createNotification<T>(
  * TODO: This is only exported to support a crazy legacy test in `groupBy`.
  * @internal
  */
-export function createNotification<T>(kind: 'N' | 'E' | 'C', value: T | undefined, error: any) {
+export function createNotification<T>(kind: 'N' | 'E' | 'C', value: T | undefined, error: unknown) {
   return {
     kind,
     value,

--- a/packages/observable/src/observable.ts
+++ b/packages/observable/src/observable.ts
@@ -29,7 +29,7 @@ export class UnsubscriptionError extends Error {
     super(
       errors
         ? `${errors.length} errors occurred during unsubscription:
-  ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}`
+  ${errors.map((err, i) => `${i + 1}) ${err}`).join('\n  ')}`
         : ''
     );
     this.name = 'UnsubscriptionError';

--- a/packages/observable/src/observable.ts
+++ b/packages/observable/src/observable.ts
@@ -303,7 +303,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
 
     // Automatically chain subscriptions together here.
     // if destination appears to be one of our subscriptions, we'll chain it.
-    if (hasAddAndUnsubscribe(destination)) {
+    if (typeof destination === "object" && hasAddAndUnsubscribe(destination)) {
       destination.add(this);
     }
   }
@@ -500,8 +500,8 @@ function handleStoppedNotification(notification: ObservableNotification<any>, su
   onStoppedNotification && setTimeout(() => onStoppedNotification(notification, subscriber));
 }
 
-function hasAddAndUnsubscribe(value: any): value is Subscription {
-  return value && isFunction(value.unsubscribe) && isFunction(value.add);
+function hasAddAndUnsubscribe(value: object | null): value is Subscription {
+  return value !== null && hasMethod(value, 'unsubscribe') && hasMethod(value, 'add');
 }
 
 export interface OperateConfig<In, Out> extends SubscriberOverrides<In> {

--- a/packages/observable/src/types.ts
+++ b/packages/observable/src/types.ts
@@ -130,7 +130,7 @@ export interface NextNotification<T> {
 export interface ErrorNotification {
   /** The kind of notification. Always "E" */
   kind: 'E';
-  error: any;
+  error: unknown;
 }
 
 /**
@@ -151,21 +151,21 @@ export type ObservableNotification<T> = NextNotification<T> | ErrorNotification 
 export interface NextObserver<T> {
   closed?: boolean;
   next: (value: T) => void;
-  error?: (err: any) => void;
+  error?: (err: unknown) => void;
   complete?: () => void;
 }
 
 export interface ErrorObserver<T> {
   closed?: boolean;
   next?: (value: T) => void;
-  error: (err: any) => void;
+  error: (err: unknown) => void;
   complete?: () => void;
 }
 
 export interface CompletionObserver<T> {
   closed?: boolean;
   next?: (value: T) => void;
-  error?: (err: any) => void;
+  error?: (err: unknown) => void;
   complete: () => void;
 }
 
@@ -196,7 +196,7 @@ export interface Observer<T> {
    *
    * For more info, please refer to {@link guide/glossary-and-semantics#error this guide}.
    */
-  error: (err: any) => void;
+  error: (err: unknown) => void;
   /**
    * A callback function that gets called by the producer if and when it has no more
    * values to provide (by calling `next` callback function). This means that no error
@@ -237,15 +237,15 @@ export interface TimestampProvider {
 }
 
 /**
- * Extracts the type from an `ObservableInput<any>`. If you have
- * `O extends ObservableInput<any>` and you pass in `Observable<number>`, or
+ * Extracts the type from an `ObservableInput<unknown>`. If you have
+ * `O extends ObservableInput<unknown>` and you pass in `Observable<number>`, or
  * `Promise<number>`, etc, it will type as `number`.
  */
 export type ObservedValueOf<O> = O extends ObservableInput<infer T> ? T : never;
 
 /**
- * Extracts a union of element types from an `ObservableInput<any>[]`.
- * If you have `O extends ObservableInput<any>[]` and you pass in
+ * Extracts a union of element types from an `ObservableInput<unknown>[]`.
+ * If you have `O extends ObservableInput<unknown>[]` and you pass in
  * `Observable<string>[]` or `Promise<string>[]` you would get
  * back a type of `string`.
  * If you pass in `[Observable<string>, Observable<number>]` you would
@@ -254,8 +254,8 @@ export type ObservedValueOf<O> = O extends ObservableInput<infer T> ? T : never;
 export type ObservedValueUnionFromArray<X> = X extends Array<ObservableInput<infer T>> ? T : never;
 
 /**
- * Extracts a tuple of element types from an `ObservableInput<any>[]`.
- * If you have `O extends ObservableInput<any>[]` and you pass in
+ * Extracts a tuple of element types from an `ObservableInput<unknown>[]`.
+ * If you have `O extends ObservableInput<unknown>[]` and you pass in
  * `[Observable<string>, Observable<number>]` you would get back a type
  * of `[string, number]`.
  */
@@ -274,23 +274,23 @@ export type ObservableInputTuple<T> = {
  * Constructs a new tuple with the specified type at the head.
  * If you declare `Cons<A, [B, C]>` you will get back `[A, B, C]`.
  */
-export type Cons<X, Y extends readonly any[]> = ((arg: X, ...rest: Y) => any) extends (...args: infer U) => any ? U : never;
+export type Cons<X, Y extends readonly unknown[]> = ((arg: X, ...rest: Y) => unknown) extends (...args: infer U) => unknown ? U : never;
 
 /**
  * Extracts the head of a tuple.
  * If you declare `Head<[A, B, C]>` you will get back `A`.
  */
-export type Head<X extends readonly any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: any[]) => any ? U : never;
+export type Head<X extends readonly unknown[]> = ((...args: X) => unknown) extends (arg: infer U, ...rest: unknown[]) => unknown ? U : never;
 
 /**
  * Extracts the tail of a tuple.
  * If you declare `Tail<[A, B, C]>` you will get back `[B, C]`.
  */
-export type Tail<X extends readonly any[]> = ((...args: X) => any) extends (arg: any, ...rest: infer U) => any ? U : never;
+export type Tail<X extends readonly unknown[]> = ((...args: X) => unknown) extends (arg: unknown, ...rest: infer U) => unknown ? U : never;
 
 /**
  * Extracts the generic value from an Array type.
- * If you have `T extends Array<any>`, and pass a `string[]` to it,
+ * If you have `T extends Array<unknown>`, and pass a `string[]` to it,
  * `ValueFromArray<T>` will return the actual type of `string`.
  */
 export type ValueFromArray<A extends readonly unknown[]> = A extends Array<infer T> ? T : never;
@@ -299,7 +299,7 @@ export type ValueFromArray<A extends readonly unknown[]> = A extends Array<infer
  * Gets the value type from an {@link ObservableNotification}, if possible.
  */
 export type ValueFromNotification<T> = T extends { kind: 'N' | 'E' | 'C' }
-  ? T extends NextNotification<any>
+  ? T extends NextNotification<unknown>
     ? T extends { value: infer V }
       ? V
       : undefined

--- a/packages/rxjs/spec/Observable-spec.ts
+++ b/packages/rxjs/spec/Observable-spec.ts
@@ -195,8 +195,8 @@ describe('Observable', () => {
 
     it('should work with handlers with hacked bind methods, in the error case', () => {
       const source = throwError(() => 'an error');
-      const results: any[] = [];
-      const error = function (value: string) {
+      const results: unknown[] = [];
+      const error = function (value: unknown) {
         results.push(value);
       };
 

--- a/packages/rxjs/spec/Subject-spec.ts
+++ b/packages/rxjs/spec/Subject-spec.ts
@@ -382,7 +382,7 @@ describe('Subject', () => {
         results3.push(x);
       },
       error: function (err) {
-        expect(false).to.equal('should not throw error: ' + err.toString());
+        expect(false).to.equal(`should not throw error: ${err}`);
       },
     });
 

--- a/packages/rxjs/spec/Subject-spec.ts
+++ b/packages/rxjs/spec/Subject-spec.ts
@@ -520,7 +520,7 @@ describe('Subject', () => {
   it('should not next after error', () => {
     const error = new Error('wut?');
     const subject = new Subject<string>();
-    const results: string[] = [];
+    const results: unknown[] = [];
     subject.subscribe({ next: (x) => results.push(x), error: (err) => results.push(err) });
     subject.next('a');
     subject.error(error);

--- a/packages/rxjs/spec/Subject-spec.ts
+++ b/packages/rxjs/spec/Subject-spec.ts
@@ -596,7 +596,7 @@ describe('Subject', () => {
 
     it('should not synchronously error when nexted into', (done) => {
       config.onUnhandledError = (err) => {
-        expect(err.message).to.equal('Boom!');
+        expect(err instanceof Error && err.message).to.equal('Boom!');
         done();
       };
 

--- a/packages/rxjs/spec/Subscriber-spec.ts
+++ b/packages/rxjs/spec/Subscriber-spec.ts
@@ -201,7 +201,7 @@ describe('Subscriber', () => {
     it('should report errors thrown from next', (done) => {
       config.onUnhandledError = (err) => {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal('test');
+        expect(err instanceof Error && err.message).to.equal('test');
         done();
       };
 
@@ -217,7 +217,7 @@ describe('Subscriber', () => {
     it('should report errors thrown from complete', (done) => {
       config.onUnhandledError = (err) => {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal('test');
+        expect(err instanceof Error && err.message).to.equal('test');
         done();
       };
 
@@ -233,7 +233,7 @@ describe('Subscriber', () => {
     it('should report errors thrown from error', (done) => {
       config.onUnhandledError = (err) => {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal('test');
+        expect(err instanceof Error && err.message).to.equal('test');
         done();
       };
 
@@ -249,7 +249,7 @@ describe('Subscriber', () => {
     it('should report errors thrown from a full observer', (done) => {
       config.onUnhandledError = (err) => {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal('thrown from next');
+        expect(err instanceof Error && err.message).to.equal('thrown from next');
         done();
       };
 
@@ -271,7 +271,7 @@ describe('Subscriber', () => {
     it('should report errors thrown from a full observer even if it is also shaped like a subscription', (done) => {
       config.onUnhandledError = (err) => {
         expect(err).to.be.an.instanceOf(Error);
-        expect(err.message).to.equal('thrown from next');
+        expect(err instanceof Error && err.message).to.equal('thrown from next');
         done();
       };
 

--- a/packages/rxjs/spec/observables/dom/ajax-spec.ts
+++ b/packages/rxjs/spec/observables/dom/ajax-spec.ts
@@ -1,8 +1,8 @@
 /** @prettier */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import type { AjaxConfig, AjaxResponse} from 'rxjs/ajax';
-import { ajax, AjaxError, AjaxTimeoutError } from 'rxjs/ajax';
+import type { AjaxConfig } from 'rxjs/ajax';
+import { ajax, AjaxError, AjaxResponse, AjaxTimeoutError } from 'rxjs/ajax';
 import { TestScheduler } from 'rxjs/testing';
 import { noop } from 'rxjs';
 import * as nodeFormData from 'form-data';
@@ -479,7 +479,8 @@ describe('ajax', () => {
     };
 
     ajax(obj).subscribe({
-      next: (x: any) => {
+      next: (x) => {
+        expect(x instanceof AjaxResponse).to.be.true;
         expect(x.status).to.equal(200);
         expect(x.xhr.method).to.equal('GET');
         expect(x.xhr.async).to.equal(true);
@@ -515,6 +516,7 @@ describe('ajax', () => {
         throw 'should not have been called';
       },
       error: (e) => {
+        expect(e instanceof AjaxTimeoutError).to.be.true;
         expect(e.status).to.equal(0);
         expect(e.xhr.method).to.equal('GET');
         expect(e.xhr.async).to.equal(true);

--- a/packages/rxjs/spec/observables/dom/ajax-spec.ts
+++ b/packages/rxjs/spec/observables/dom/ajax-spec.ts
@@ -481,9 +481,13 @@ describe('ajax', () => {
     ajax(obj).subscribe({
       next: (x) => {
         expect(x instanceof AjaxResponse).to.be.true;
+        if (!(x instanceof AjaxResponse))
+          return; // type-narrowing that @types/chai can't do
+
         expect(x.status).to.equal(200);
-        expect(x.xhr.method).to.equal('GET');
-        expect(x.xhr.async).to.equal(true);
+        // fields only in MockXMLHttpRequest:
+        expect('method' in x.xhr && x.xhr.method).to.equal('GET');
+        expect('async' in x.xhr && x.xhr.async).to.equal(true);
         expect(x.xhr.timeout).to.equal(10);
         expect(x.xhr.responseType).to.equal('text');
       },
@@ -517,9 +521,13 @@ describe('ajax', () => {
       },
       error: (e) => {
         expect(e instanceof AjaxTimeoutError).to.be.true;
+        if (!(e instanceof AjaxTimeoutError))
+          return; // type-narrowing that @types/chai can't do
+
         expect(e.status).to.equal(0);
-        expect(e.xhr.method).to.equal('GET');
-        expect(e.xhr.async).to.equal(true);
+        // fields only in MockXMLHttpRequest:
+        expect('method' in e.xhr && e.xhr.method).to.equal('GET');
+        expect('async' in e.xhr && e.xhr.async).to.equal(true);
         expect(e.xhr.timeout).to.equal(10);
         expect(e.xhr.responseType).to.equal('text');
       },

--- a/packages/rxjs/spec/observables/dom/ajax-spec.ts
+++ b/packages/rxjs/spec/observables/dom/ajax-spec.ts
@@ -292,7 +292,7 @@ describe('ajax', () => {
       next: () => {
         done(new Error('should not be called'));
       },
-      error: (e: Error) => {
+      error: (e) => {
         expect(e).to.be.equal(expected);
         done();
       },
@@ -663,7 +663,7 @@ describe('ajax', () => {
         next: () => {
           done(new Error('should not be called'));
         },
-        error: (e: Error) => {
+        error: (e) => {
           expect(e).to.be.equal(expected);
           done();
         },

--- a/packages/rxjs/spec/observables/from-spec.ts
+++ b/packages/rxjs/spec/observables/from-spec.ts
@@ -325,7 +325,7 @@ describe('from', () => {
 
     from(erroringIterator).subscribe({
       next: (x) => results.push(x),
-      error: (err) => results.push(err.message),
+      error: (err) => results.push(err instanceof Error && err.message),
     });
 
     expect(results).to.deep.equal([0, 1, 2, 'bad']);

--- a/packages/rxjs/spec/observables/fromEvent-spec.ts
+++ b/packages/rxjs/spec/observables/fromEvent-spec.ts
@@ -492,7 +492,7 @@ describe('fromEvent', () => {
     source.subscribe({
       error: (err) => {
         expect(err).to.be.an.instanceOf(TypeError);
-        expect(err.message).to.equal('Invalid event target');
+        expect(err instanceof TypeError && err.message).to.equal('Invalid event target');
         done();
       },
     });

--- a/packages/rxjs/spec/operators/tap-spec.ts
+++ b/packages/rxjs/spec/operators/tap-spec.ts
@@ -325,7 +325,7 @@ describe('tap', () => {
           tap({
             subscribe: () => results.push('subscribe'),
             next: (value) => results.push(`next ${value}`),
-            error: (err) => results.push(`error: ${err.message}`),
+            error: (err) => results.push(`error: ${err}`),
             complete: () => results.push('complete'),
             unsubscribe: () => results.push('unsubscribe'),
             finalize: () => results.push('finalize'),
@@ -351,7 +351,7 @@ describe('tap', () => {
           tap({
             subscribe: () => results.push('subscribe'),
             next: (value) => results.push(`next ${value}`),
-            error: (err) => results.push(`error: ${err.message}`),
+            error: (err) => results.push(`error: ${err}`),
             complete: () => results.push('complete'),
             unsubscribe: () => results.push('unsubscribe'),
             finalize: () => results.push('finalize'),
@@ -378,7 +378,7 @@ describe('tap', () => {
           tap({
             subscribe: () => results.push('subscribe'),
             next: (value) => results.push(`next ${value}`),
-            error: (err) => results.push(`error: ${err.message}`),
+            error: (err) => results.push(`error: ${err}`),
             complete: () => results.push('complete'),
             unsubscribe: () => results.push('unsubscribe'),
             finalize: () => results.push('finalize'),

--- a/packages/rxjs/spec/subjects/ReplaySubject-spec.ts
+++ b/packages/rxjs/spec/subjects/ReplaySubject-spec.ts
@@ -120,7 +120,7 @@ describe('ReplaySubject', () => {
         function feedNextIntoSubject(x: string) {
           replaySubject.next(x);
         }
-        function feedErrorIntoSubject(err: string) {
+        function feedErrorIntoSubject(err: unknown) {
           replaySubject.error(err);
         }
         function feedCompleteIntoSubject() {
@@ -152,7 +152,7 @@ describe('ReplaySubject', () => {
         function feedNextIntoSubject(x: string) {
           replaySubject.next(x);
         }
-        function feedErrorIntoSubject(err: string) {
+        function feedErrorIntoSubject(err: unknown) {
           replaySubject.error(err);
         }
         function feedCompleteIntoSubject() {

--- a/packages/rxjs/src/internal/Subject.ts
+++ b/packages/rxjs/src/internal/Subject.ts
@@ -39,7 +39,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
   hasError = false;
 
   /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
-  thrownError: any = null;
+  thrownError: unknown = null;
 
   constructor() {
     // NOTE: This must be here to obscure Observable's constructor.
@@ -61,7 +61,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     }
   }
 
-  error(err: any) {
+  error(err: unknown) {
     if (!this._closed) {
       this.hasError = this._closed = true;
       this.thrownError = err;

--- a/packages/rxjs/src/internal/ajax/ajax.ts
+++ b/packages/rxjs/src/internal/ajax/ajax.ts
@@ -410,7 +410,7 @@ export function fromAjax<T>(init: AjaxConfig): Observable<AjaxResponse<T>> {
        * @param type The type of event we're treating as an error
        * @param errorFactory A function that creates the type of error to emit.
        */
-      const addErrorEvent = (type: string, errorFactory: () => any) => {
+      const addErrorEvent = (type: string, errorFactory: () => Error) => {
         xhr.addEventListener(type, () => {
           const error = errorFactory();
           progressSubscriber?.error?.(error);
@@ -576,34 +576,34 @@ function extractContentTypeAndMaybeSerializeBody(body: any, headers: Record<stri
 
 const _toString = Object.prototype.toString;
 
-function toStringCheck(obj: any, name: string): boolean {
+function toStringCheck(obj: unknown, name: string): boolean {
   return _toString.call(obj) === `[object ${name}]`;
 }
 
-function isArrayBuffer(body: any): body is ArrayBuffer {
+function isArrayBuffer(body: unknown): body is ArrayBuffer {
   return toStringCheck(body, 'ArrayBuffer');
 }
 
-function isFile(body: any): body is File {
+function isFile(body: unknown): body is File {
   return toStringCheck(body, 'File');
 }
 
-function isBlob(body: any): body is Blob {
+function isBlob(body: unknown): body is Blob {
   return toStringCheck(body, 'Blob');
 }
 
-function isArrayBufferView(body: any): body is ArrayBufferView {
+function isArrayBufferView(body: unknown): body is ArrayBufferView {
   return typeof ArrayBuffer !== 'undefined' && ArrayBuffer.isView(body);
 }
 
-function isFormData(body: any): body is FormData {
+function isFormData(body: unknown): body is FormData {
   return typeof FormData !== 'undefined' && body instanceof FormData;
 }
 
-function isURLSearchParams(body: any): body is URLSearchParams {
+function isURLSearchParams(body: unknown): body is URLSearchParams {
   return typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams;
 }
 
-function isReadableStream(body: any): body is ReadableStream {
+function isReadableStream(body: unknown): body is ReadableStream {
   return typeof ReadableStream !== 'undefined' && body instanceof ReadableStream;
 }

--- a/packages/rxjs/src/internal/operators/tap.ts
+++ b/packages/rxjs/src/internal/operators/tap.ts
@@ -1,5 +1,5 @@
 import type { MonoTypeOperatorFunction, Observer } from '../types.js';
-import { Observable, operate, isFunction } from '@rxjs/observable';
+import { Observable, operate } from '@rxjs/observable';
 import { identity } from '../util/identity.js';
 
 /**
@@ -155,7 +155,7 @@ export interface TapObserver<T> extends Observer<T> {
  */
 export function tap<T>(observerOrNext?: Partial<TapObserver<T>> | ((value: T) => void) | null): MonoTypeOperatorFunction<T> {
   // Just need to see if it's a function or a partial observer.
-  const tapObserver: Partial<TapObserver<T>> | null | undefined = isFunction(observerOrNext) ? { next: observerOrNext } : observerOrNext;
+  const tapObserver: Partial<TapObserver<T>> | null | undefined = typeof observerOrNext === 'function' ? { next: observerOrNext } : observerOrNext;
 
   return tapObserver
     ? (source) =>

--- a/packages/rxjs/src/internal/types.ts
+++ b/packages/rxjs/src/internal/types.ts
@@ -130,7 +130,7 @@ export interface NextNotification<T> {
 export interface ErrorNotification {
   /** The kind of notification. Always "E" */
   kind: 'E';
-  error: any;
+  error: unknown;
 }
 
 /**
@@ -151,21 +151,21 @@ export type ObservableNotification<T> = NextNotification<T> | ErrorNotification 
 export interface NextObserver<T> {
   closed?: boolean;
   next: (value: T) => void;
-  error?: (err: any) => void;
+  error?: (err: unknown) => void;
   complete?: () => void;
 }
 
 export interface ErrorObserver<T> {
   closed?: boolean;
   next?: (value: T) => void;
-  error: (err: any) => void;
+  error: (err: unknown) => void;
   complete?: () => void;
 }
 
 export interface CompletionObserver<T> {
   closed?: boolean;
   next?: (value: T) => void;
-  error?: (err: any) => void;
+  error?: (err: unknown) => void;
   complete: () => void;
 }
 
@@ -196,7 +196,7 @@ export interface Observer<T> {
    *
    * For more info, please refer to {@link guide/glossary-and-semantics#error this guide}.
    */
-  error: (err: any) => void;
+  error: (err: unknown) => void;
   /**
    * A callback function that gets called by the producer if and when it has no more
    * values to provide (by calling `next` callback function). This means that no error
@@ -237,15 +237,15 @@ export interface TimestampProvider {
 }
 
 /**
- * Extracts the type from an `ObservableInput<any>`. If you have
- * `O extends ObservableInput<any>` and you pass in `Observable<number>`, or
+ * Extracts the type from an `ObservableInput<unknown>`. If you have
+ * `O extends ObservableInput<unknown>` and you pass in `Observable<number>`, or
  * `Promise<number>`, etc, it will type as `number`.
  */
 export type ObservedValueOf<O> = O extends ObservableInput<infer T> ? T : never;
 
 /**
- * Extracts a union of element types from an `ObservableInput<any>[]`.
- * If you have `O extends ObservableInput<any>[]` and you pass in
+ * Extracts a union of element types from an `ObservableInput<unknown>[]`.
+ * If you have `O extends ObservableInput<unknown>[]` and you pass in
  * `Observable<string>[]` or `Promise<string>[]` you would get
  * back a type of `string`.
  * If you pass in `[Observable<string>, Observable<number>]` you would
@@ -254,8 +254,8 @@ export type ObservedValueOf<O> = O extends ObservableInput<infer T> ? T : never;
 export type ObservedValueUnionFromArray<X> = X extends Array<ObservableInput<infer T>> ? T : never;
 
 /**
- * Extracts a tuple of element types from an `ObservableInput<any>[]`.
- * If you have `O extends ObservableInput<any>[]` and you pass in
+ * Extracts a tuple of element types from an `ObservableInput<unknown>[]`.
+ * If you have `O extends ObservableInput<unknown>[]` and you pass in
  * `[Observable<string>, Observable<number>]` you would get back a type
  * of `[string, number]`.
  */
@@ -274,23 +274,23 @@ export type ObservableInputTuple<T> = {
  * Constructs a new tuple with the specified type at the head.
  * If you declare `Cons<A, [B, C]>` you will get back `[A, B, C]`.
  */
-export type Cons<X, Y extends readonly any[]> = ((arg: X, ...rest: Y) => any) extends (...args: infer U) => any ? U : never;
+export type Cons<X, Y extends readonly unknown[]> = ((arg: X, ...rest: Y) => unknown) extends (...args: infer U) => unknown ? U : never;
 
 /**
  * Extracts the head of a tuple.
  * If you declare `Head<[A, B, C]>` you will get back `A`.
  */
-export type Head<X extends readonly any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: any[]) => any ? U : never;
+export type Head<X extends readonly unknown[]> = ((...args: X) => unknown) extends (arg: infer U, ...rest: unknown[]) => unknown ? U : never;
 
 /**
  * Extracts the tail of a tuple.
  * If you declare `Tail<[A, B, C]>` you will get back `[B, C]`.
  */
-export type Tail<X extends readonly any[]> = ((...args: X) => any) extends (arg: any, ...rest: infer U) => any ? U : never;
+export type Tail<X extends readonly unknown[]> = ((...args: X) => unknown) extends (arg: unknown, ...rest: infer U) => unknown ? U : never;
 
 /**
  * Extracts the generic value from an Array type.
- * If you have `T extends Array<any>`, and pass a `string[]` to it,
+ * If you have `T extends Array<unknown>`, and pass a `string[]` to it,
  * `ValueFromArray<T>` will return the actual type of `string`.
  */
 export type ValueFromArray<A extends readonly unknown[]> = A extends Array<infer T> ? T : never;
@@ -299,7 +299,7 @@ export type ValueFromArray<A extends readonly unknown[]> = A extends Array<infer
  * Gets the value type from an {@link ObservableNotification}, if possible.
  */
 export type ValueFromNotification<T> = T extends { kind: 'N' | 'E' | 'C' }
-  ? T extends NextNotification<any>
+  ? T extends NextNotification<unknown>
     ? T extends { value: infer V }
       ? V
       : undefined


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Replace a bunch of `any` types with either `unknown` or a more specific type.

But two are harder to replace, changing them causes type errors:

https://github.com/ReactiveX/rxjs/blob/c15b37f81ba5f5abea8c872b0189a70b150df4cb/packages/observable/src/observable.ts#L262
https://github.com/ReactiveX/rxjs/blob/c15b37f81ba5f5abea8c872b0189a70b150df4cb/packages/observable/src/observable.ts#L498

```
  Type 'Subscriber<T>' is not assignable to type 'Subscriber<unknown>'.
    Type 'unknown' is not assignable to type 'T'.
```

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**

Part of the 8.x roadmap in #6367 

>  Replace *all* external uses of `any` with `unknown`. (This could likely be non-breaking, FWIW.)
