### PR TITLE
fix 'new Subject()' and 'new Observable()'

### DIFF
--- a/spec-dtslint/Subject-spec.ts
+++ b/spec-dtslint/Subject-spec.ts
@@ -2,11 +2,10 @@ import { Subject } from 'rxjs';
 
 describe('Subject', () => {
   it('should handle no generic appropriately', () => {
-    const s1 = new Subject(); // $ExpectType Subject<unknown>
-    s1.next(); // $ExpectError
-    s1.next('test'); // $ExpectType void
-    s1.subscribe(value => {
-      const x = value; // $ExpectType unknown
+    const s1 = new Subject(); // $ExpectType Subject<void>
+    s1.next(); // $ExpectType void
+    s1.next('test'); // $ExpectError
+    s1.subscribe(() => {
     });
   });
 
@@ -37,7 +36,7 @@ describe('Subject', () => {
   describe('asObservable', () => {
     it('should return an observable of the same generic type', () => {
       const s1 = new Subject();
-      const o1 = s1.asObservable(); // $ExpectType Observable<unknown>
+      const o1 = s1.asObservable(); // $ExpectType Observable<void>
 
       const s2 = new Subject<string>();
       const o2 = s2.asObservable(); // $ExpectType Observable<string>

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -643,7 +643,7 @@ describe('Observable', () => {
       });
 
       it('should rethrow if next handler throws', () => {
-        const observable = new Observable((observer) => {
+        const observable = new Observable<number>((observer) => {
           observer.next(1);
         });
 

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -695,7 +695,7 @@ describe('AnonymousSubject', () => {
 
     const subject = Subject.create(
       null,
-      new Observable((observer: Observer<any>) => {
+      new Observable<string>((observer: Observer<string>) => {
         subscribed = true;
         const subscription = of('x').subscribe(observer);
         return () => {

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -846,7 +846,7 @@ describe('useDeprecatedSynchronousErrorHandling', () => {
   });
 
   it('deep rethrowing 1', () => {
-    const subject1 = new Subject();
+    const subject1 = new Subject<string>();
     const subject2 = new Subject();
 
     subject2.subscribe();
@@ -861,7 +861,7 @@ describe('useDeprecatedSynchronousErrorHandling', () => {
   });
 
   it('deep rethrowing 2', () => {
-    const subject1 = new Subject();
+    const subject1 = new Subject<string>();
 
     subject1.subscribe({
       next: () => {

--- a/spec/config-spec.ts
+++ b/spec/config-spec.ts
@@ -186,7 +186,7 @@ describe('config', () => {
         done();
       };
 
-      const source = new Observable((subscriber) => {
+      const source = new Observable<number>((subscriber) => {
         subscriber.next(1);
         subscriber.complete();
         subscriber.next(2);

--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -446,7 +446,7 @@ describe('audit operator', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/bufferCount-spec.ts
+++ b/spec/operators/bufferCount-spec.ts
@@ -167,7 +167,7 @@ describe('bufferCount operator', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/catchError-spec.ts
+++ b/spec/operators/catchError-spec.ts
@@ -462,7 +462,7 @@ describe('catchError operator', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/concatAll-spec.ts
+++ b/spec/operators/concatAll-spec.ts
@@ -544,7 +544,7 @@ describe('concatAll operator', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -848,7 +848,7 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/concatMapTo-spec.ts
+++ b/spec/operators/concatMapTo-spec.ts
@@ -409,7 +409,7 @@ describe('concatMapTo', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/concatWith-spec.ts
+++ b/spec/operators/concatWith-spec.ts
@@ -335,7 +335,7 @@ describe('concat operator', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -532,7 +532,7 @@ describe('debounce', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/defaultIfEmpty-spec.ts
+++ b/spec/operators/defaultIfEmpty-spec.ts
@@ -101,7 +101,7 @@ describe('defaultIfEmpty', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/every-spec.ts
+++ b/spec/operators/every-spec.ts
@@ -75,7 +75,7 @@ describe('every', () => {
   it('should accept thisArg with ordinary observable', () => {
     const thisArg = {};
 
-    const source = new Observable((observer: Observer<number>) => {
+    const source = new Observable<number>((observer: Observer<number>) => {
       observer.next(1);
       observer.complete();
     });

--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -277,7 +277,7 @@ describe('finalize', () => {
 
   it('should execute finalize even with a sync thrown error', () => {
     let called = false;
-    const badObservable = new Observable(() => {
+    const badObservable = new Observable<number>(() => {
       throw new Error('bad');
     }).pipe(
       finalize(() => {
@@ -294,7 +294,7 @@ describe('finalize', () => {
 
   it('should execute finalize in order even with a sync error', () => {
     const results: any[] = [];
-    const badObservable = new Observable((subscriber) => {
+    const badObservable = new Observable<number>((subscriber) => {
       subscriber.error(new Error('bad'));
     }).pipe(
       finalize(() => {
@@ -314,7 +314,7 @@ describe('finalize', () => {
 
   it('should execute finalize in order even with a sync thrown error', () => {
     const results: any[] = [];
-    const badObservable = new Observable(() => {
+    const badObservable = new Observable<number>(() => {
       throw new Error('bad');
     }).pipe(
       finalize(() => {

--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -619,7 +619,7 @@ describe('multicast', () => {
 
     it('should be repeatable', () => {
       testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
-        const subjectFactory = () => new Subject();
+        const subjectFactory = () => new Subject<string>();
 
         const e1 = cold('   -1-2-3----4-|                        ');
         const e1subs = [

--- a/spec/operators/onErrorResumeNext-spec.ts
+++ b/spec/operators/onErrorResumeNext-spec.ts
@@ -168,7 +168,7 @@ describe('onErrorResumeNext', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable((subscriber) => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {

--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -32,7 +32,7 @@ describe('retry', () => {
   it('should retry a number of times, without error, then complete', (done) => {
     let errors = 0;
     const retries = 2;
-    new Observable((observer: Observer<number>) => {
+    new Observable<number>((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
     })
@@ -60,7 +60,7 @@ describe('retry', () => {
   it('should retry a number of times, then call error handler', (done) => {
     let errors = 0;
     const retries = 2;
-    new Observable((observer: Observer<number>) => {
+    new Observable<number>((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
     })
@@ -88,7 +88,7 @@ describe('retry', () => {
   it('should retry a number of times, then call error handler (with resetOnSuccess)', (done) => {
     let errors = 0;
     const retries = 2;
-    new Observable((observer: Observer<number>) => {
+    new Observable<number>((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
     })
@@ -197,7 +197,7 @@ describe('retry', () => {
   it('should retry until successful completion', (done) => {
     let errors = 0;
     const retries = 10;
-    new Observable((observer: Observer<number>) => {
+    new Observable<number>((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
     })

--- a/spec/operators/share-spec.ts
+++ b/spec/operators/share-spec.ts
@@ -681,7 +681,7 @@ describe('share', () => {
   describe('share(config) with async/deferred reset notifiers', () => {
     it('should reset on refCount 0 when synchronously resubscribing to a firehose and using a sync reset notifier', () => {
       let subscriptionCount = 0;
-      const source = new Observable((subscriber) => {
+      const source = new Observable<number>((subscriber) => {
         subscriptionCount++;
         for (let i = 0; i < 3 && !subscriber.closed; i++) {
           subscriber.next(i);

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -28,7 +28,7 @@ describe('shareReplay', () => {
 
   it('should do nothing if result is not subscribed', () => {
     let subscribed = false;
-    const source = new Observable(() => {
+    const source = new Observable<number>(() => {
       subscribed = true;
     });
     source.pipe(shareReplay());

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -12,7 +12,7 @@ import { errorContext } from './util/errorContext';
  * A representation of any set of values over any amount of time. This is the most basic building block
  * of RxJS.
  */
-export class Observable<T> implements Subscribable<T> {
+export class Observable<T = void> implements Subscribable<T> {
   /**
    * @deprecated Internal implementation detail, do not use directly. Will be made internal in v8.
    */

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -14,7 +14,7 @@ import { errorContext } from './util/errorContext';
  * Every Subject is an Observable and an Observer. You can subscribe to a
  * Subject, and you can call next to feed values as well as error and complete.
  */
-export class Subject<T> extends Observable<T> implements SubscriptionLike {
+export class Subject<T = void> extends Observable<T> implements SubscriptionLike {
   closed = false;
 
   private currentObservers: Observer<T>[] | null = null;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

As pointed out in #7536, the docs for rxjs 7+ have specifically said this since #5307:

https://github.com/ReactiveX/rxjs/blob/c15b37f81ba5f5abea8c872b0189a70b150df4cb/apps/rxjs.dev/content/guide/subject.md#L368

https://github.com/ReactiveX/rxjs/blob/c15b37f81ba5f5abea8c872b0189a70b150df4cb/apps/rxjs.dev/content/guide/subject.md#L377

But the `<T = void>` was removed for unexplained reasons in #5430 even though the docs were never updated.

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

Code that depends on `new Subject()` returning `Subject<unknown>` will break.

**Related issue (if exists):**

This also had to fix tests missing type parameters from #3449 #5750 #6216 #6478