### PR TITLE
docs: add missing operator examples and fix test setup for Node 24

### DIFF
--- a/packages/rxjs/spec/helpers/setup.ts
+++ b/packages/rxjs/spec/helpers/setup.ts
@@ -61,4 +61,5 @@ if (typeof Symbol.dispose !== 'symbol') {
 
 
 //setup sinon-chai
-chai.use(sinonChai);
+// In Node 24+ ESM interop, `import * as x` wraps the CJS default export under `.default`
+chai.use((sinonChai as any).default ?? sinonChai);

--- a/packages/rxjs/src/internal/operators/throttleTime.ts
+++ b/packages/rxjs/src/internal/operators/throttleTime.ts
@@ -37,6 +37,22 @@ import { timer } from '../observable/timer.js';
  * result.subscribe(x => console.log(x));
  * ```
  *
+ * ### Throttle with trailing emission
+ *
+ * Emit both the first and the last value in each throttle window by setting
+ * `leading: true` and `trailing: true` in the config
+ *
+ * ```ts
+ * import { fromEvent, throttleTime } from 'rxjs';
+ *
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(
+ *   throttleTime(1000, undefined, { leading: true, trailing: true })
+ * );
+ *
+ * result.subscribe(x => console.log(x));
+ * ```
+ *
  * @see {@link auditTime}
  * @see {@link debounceTime}
  * @see {@link delay}

--- a/packages/rxjs/src/internal/operators/zipAll.ts
+++ b/packages/rxjs/src/internal/operators/zipAll.ts
@@ -7,8 +7,55 @@ import { joinAllInternals } from './joinAllInternals.js';
  * it will subscribe to all inner sources, combining their values by index and emitting
  * them.
  *
+ * <span class="informal">Waits for an outer Observable to complete, then zips
+ * together each inner Observable's values by index into an array.</span>
+ *
+ * ![](zipAll.png)
+ *
+ * `zipAll` subscribes to a higher-order Observable (an Observable of Observables). Once the
+ * outer Observable completes, it subscribes to all collected inner Observables and emits
+ * arrays of values, where the _n_-th array contains the _n_-th value from each inner Observable.
+ * The resulting Observable completes when the shortest inner Observable completes.
+ *
+ * ## Examples
+ *
+ * ### Map to inner Observables and zip them together
+ *
+ * ```ts
+ * import { of, zipAll } from 'rxjs';
+ *
+ * const obs1 = of(1, 2, 3);
+ * const obs2 = of('a', 'b', 'c');
+ *
+ * of(obs1, obs2).pipe(
+ *   zipAll()
+ * ).subscribe(console.log);
+ *
+ * // [1, 'a']
+ * // [2, 'b']
+ * // [3, 'c']
+ * ```
+ *
+ * ### Use a project function to combine values
+ *
+ * ```ts
+ * import { of, zipAll } from 'rxjs';
+ *
+ * const obs1 = of(1, 2, 3);
+ * const obs2 = of('a', 'b', 'c');
+ *
+ * of(obs1, obs2).pipe(
+ *   zipAll((num, str) => `${num}-${str}`)
+ * ).subscribe(console.log);
+ *
+ * // '1-a'
+ * // '2-b'
+ * // '3-c'
+ * ```
+ *
  * @see {@link zipWith}
  * @see {@link zip}
+ * @see {@link combineLatestAll}
  */
 export function zipAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export function zipAll<T>(): OperatorFunction<any, T[]>;


### PR DESCRIPTION
Description:
  Closes #4647, #4823

  **Changes:**

  - `docs(zipAll)`: adds informal description, marble diagram reference (`zipAll.png`
    already existed), and two code examples — basic usage and with a project function
  - `docs(throttleTime)`: adds a second example demonstrating `ThrottleConfig` with
    `{ leading: true, trailing: true }` to show the trailing emission behavior
  - `fix(testing)`: `chai.use(sinonChai)` throws on Node 24 because `import * as x`
    wraps a CJS module in an ESM namespace object. Added `.default ?? x` fallback
    to handle both old and new Node interop without breaking existing behavior

  **Related issues:** #4647, #4823