### PR TITLE
fix(rxjs): prevent clearing RAF scheduled id if it does not match the action id

### DIFF
--- a/packages/rxjs/src/internal/scheduler/AnimationFrameAction.ts
+++ b/packages/rxjs/src/internal/scheduler/AnimationFrameAction.ts
@@ -35,7 +35,9 @@ export class AnimationFrameAction<T> extends AsyncAction<T> {
     const { actions } = scheduler;
     if (id != null && actions[actions.length - 1]?.id !== id) {
       animationFrameProvider.cancelAnimationFrame(id as number);
-      scheduler._scheduled = undefined;
+      if (scheduler._scheduled === id) {
+        scheduler._scheduled = undefined;
+      }
     }
     // Return undefined so the action knows to request a new async id if it's rescheduled.
     return undefined;


### PR DESCRIPTION
**Description:**

When using animationFrameScheduler and recycling the async id the action might remove the latest schedlued id from the scheduler, which makes the scheduler stop firing.

See https://github.com/ReactiveX/rxjs/pull/7198

I couldn't find a way to test this properly. It seems to happen very randomly, but the fix does solve our case


**Related issue (if exists):**

Found a stackoverflow thread from years ago: https://stackoverflow.com/questions/72916854/rxjs-animationframescheduler-stops-working-unexpectedly
