### PR TITLE
docs(throttleTime): add config example

### DIFF
--- a/packages/rxjs/src/internal/operators/throttleTime.ts
+++ b/packages/rxjs/src/internal/operators/throttleTime.ts
@@ -37,9 +37,24 @@ import { timer } from '../observable/timer.js';
  * result.subscribe(x => console.log(x));
  * ```
  *
+ * ### Emit the first click immediately, then emit the latest click after one second
+ *
+ * ```ts
+ * import { asyncScheduler, fromEvent, throttleTime } from 'rxjs';
+ *
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(throttleTime(1000, asyncScheduler, { trailing: true }));
+ *
+ * result.subscribe(x => console.log(x));
+ * ```
+ *
+ * @see {@link audit}
  * @see {@link auditTime}
+ * @see {@link debounce}
  * @see {@link debounceTime}
  * @see {@link delay}
+ * @see {@link delayWhen}
+ * @see {@link sample}
  * @see {@link sampleTime}
  * @see {@link throttle}
  *


### PR DESCRIPTION
## Summary
- add a `throttleTime` example that passes a `ThrottleConfig` with `{ trailing: true }`
- add the related timing/filtering operators that were missing from the local `@see` list

Fixes #4647

## Validation
- `git diff HEAD^..HEAD --check`
- `node` content check confirming the new config example and `@see` links are present

## Notes
- I found the older merged PR #4698, so this keeps the scope narrow: it adds one current-source example for the config parameter rather than changing behavior or generated docs assets.
- I did not run the full docs/test suite locally because this shallow clone does not have `node_modules` installed.
