### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/packages/rxjs/README.md
+++ b/packages/rxjs/README.md
@@ -37,6 +37,12 @@ By contributing or commenting on issues in this repository, whether you've read 
 npm install rxjs
 ```
 
+Or, using [Deno](https://deno.com/):
+
+```shell
+deno install rxjs
+```
+
 It's recommended to pull in the Observable creation methods you need directly from `'rxjs'` as shown below with `range`.
 If you're using RxJS version 7.2 or above, you can pull in any operator you need from the same spot, `'rxjs'`.
 


### PR DESCRIPTION
**Description:**

👋 Bartek from the Deno team here.

The install instructions list npm, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install rxjs
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install rxjs`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it to a docs site instead.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._

**Related issue (if exists):** N/A
