### PR TITLE
fix(takeLast): prevent RangeError when count is Infinity

### DIFF
--- a/packages/rxjs/spec/operators/takeLast-spec.ts
+++ b/packages/rxjs/spec/operators/takeLast-spec.ts
@@ -1,4 +1,5 @@
 import { takeLast, mergeMap } from 'rxjs/operators';
+import { expect } from 'chai';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
@@ -203,6 +204,27 @@ describe('takeLast operator', () => {
 
       expectObservable(result, unsub).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+  });
+
+  it('should not throw when count is Infinity and should emit all values', () => {
+    const results: number[] = [];
+    expect(() => {
+      of(1, 2, 3)
+        .pipe(takeLast(Infinity))
+        .subscribe((x) => results.push(x));
+    }).not.to.throw();
+    expect(results).to.deep.equal([1, 2, 3]);
+  });
+
+  it('should emit all values when count exceeds source length (Infinity case)', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('(abc|)');
+      const expected = '   (abc|)';
+      const subs = '       (^!)';
+
+      expectObservable(source.pipe(takeLast(Infinity))).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
     });
   });
 });

--- a/packages/rxjs/src/internal/operators/takeLast.ts
+++ b/packages/rxjs/src/internal/operators/takeLast.ts
@@ -46,8 +46,11 @@ export function takeLast<T>(count: number): MonoTypeOperatorFunction<T> {
     ? () => EMPTY
     : (source) =>
         new Observable((destination) => {
-          // This is a ring buffer that will hold our values
-          let ring = new Array<T>(count);
+          // This is a ring buffer that will hold our values.
+          // For non-finite counts (e.g. Infinity), use a growable array because
+          // `new Array(Infinity)` throws a RangeError. The ring-buffer math still
+          // works correctly for Infinity since `n % Infinity === n` for all finite n.
+          let ring: T[] = isFinite(count) ? new Array<T>(count) : [];
           // This counter is how we track where we are at in the ring buffer.
           let counter = 0;
           source.subscribe(


### PR DESCRIPTION
## Problem

`takeLast(Infinity)` throws a `RangeError: Invalid array length` at subscription time:

```ts
// Throws: RangeError: Invalid array length
of(1, 2, 3).pipe(takeLast(Infinity)).subscribe(console.log);
```

The cause is line 50 of `takeLast.ts`:

```ts
let ring = new Array<T>(count);  // new Array(Infinity) → RangeError
```

JavaScript forbids creating an array with a non-integer or infinite length argument.

## Fix

Use a growable array (`[]`) when `count` is non-finite. The ring-buffer index arithmetic already handles `Infinity` correctly because `n % Infinity === n` for every finite `n`, so no further changes to the logic are required:

```ts
let ring: T[] = isFinite(count) ? new Array<T>(count) : [];
```

After the fix, `takeLast(Infinity)` behaves like `takeLast(n)` where `n >= source.length`: it buffers every value and emits them all on completion.

## Tests

Two new tests added to `takeLast-spec.ts`:
- Synchronous assertion that no error is thrown and all values are emitted
- Marble test verifying the observable shape matches the source

> *This fix was developed with AI assistance.*