### PR TITLE
fix(zip): handle when unsubscribe is called from within next

### DIFF
--- a/packages/rxjs/src/internal/observable/zip.ts
+++ b/packages/rxjs/src/internal/observable/zip.ts
@@ -88,7 +88,7 @@ export function zip(...args: unknown[]): Observable<unknown> {
                   // If any one of the sources is both complete and has an empty buffer
                   // then we complete the result. This is because we cannot possibly have
                   // any more values to zip together.
-                  if (buffers.some((buffer, i) => !buffer.length && completed[i])) {
+                  if (buffers?.some((buffer, i) => !buffer.length && completed[i])) {
                     destination.complete();
                   }
                 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR is an updated version of #6955. It fixes an error which occurs if someone closes a source observable during the next call of a `zip()` operator.

**Related issue (if exists):** #6716
